### PR TITLE
Add universal macOS Mercurial bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,6 @@ mercurial/* filter=lfs diff=lfs merge=lfs -text
 mercurial/SOURCE filter= diff= merge= text
 mercurial/LICENSE filter= diff= merge= text
 mercurial-macos/**/* filter=lfs diff=lfs merge=lfs -text
-mercurial-macos/SOURCE filter= diff= merge= text
+mercurial-macos/SOURCE.md filter= diff= merge= text
 mercurial-macos/LICENSE filter= diff= merge= text
 * text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,7 @@ lexical-db/lexical.db.xz.sha256 filter= diff= merge= text
 mercurial/* filter=lfs diff=lfs merge=lfs -text
 mercurial/SOURCE filter= diff= merge= text
 mercurial/LICENSE filter= diff= merge= text
+mercurial-macos/**/* filter=lfs diff=lfs merge=lfs -text
+mercurial-macos/SOURCE filter= diff= merge= text
+mercurial-macos/LICENSE filter= diff= merge= text
 * text=auto

--- a/mercurial-macos/LICENSE
+++ b/mercurial-macos/LICENSE
@@ -1,0 +1,10 @@
+This bundle includes:
+
+• **Mercurial (hg)** — distributed under the GNU General Public License version 2 or later (GPL-2.0-or-later).  
+• **Python 3.13 runtime and standard library** — distributed under the Python Software Foundation License (PSF License, version 2).  
+
+References:
+- Mercurial license: GPL-2.0-or-later  [oai_citation:0‡Wikipedia](https://en.wikipedia.org/wiki/Mercurial?utm_source=chatgpt.com)  
+- Python license: PSF License Version 2  [oai_citation:1‡Python documentation](https://docs.python.org/3/license.html?utm_source=chatgpt.com) [oai_citation:2‡Wikipedia](https://en.wikipedia.org/wiki/Python_Software_Foundation_License?utm_source=chatgpt.com)  
+
+Please review the full license texts in the respective project repositories for exact terms and conditions.

--- a/mercurial-macos/SOURCE.md
+++ b/mercurial-macos/SOURCE.md
@@ -1,3 +1,44 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67036736efb7ce6ee4a7e1081945f65adc87be6ffbac1c52f07e63e5630ffc1b
-size 1309
+# Source
+
+## Technical Source
+
+The Mercurial bundle in this directory was built from MacPorts with universal architecture support.
+
+To build:
+
+1. Install Mercurial with universal architecture:
+   ```bash
+   sudo port install mercurial +universal
+   ```
+2. Copy the Mercurial launcher and Python runtime:
+   ```bash
+   mkdir hg-universal
+   cp /opt/local/bin/hg hg-universal/
+   cp -R /opt/local/Library/Frameworks/Python.framework/Versions/3.13 hg-universal/
+   ```
+3. Test:
+   ```bash
+   ./hg-universal/hg version
+   ```
+4. Create compressed archive:
+   ```bash
+   tar -c --xz -f hg-macos-universal.tar.xz hg-universal
+   ```
+5. Generate checksum file:
+   ```bash
+   shasum -a 256 hg-macos-universal.tar.xz > hg-macos-universal.tar.xz.sha256
+   ```
+
+The resulting archive contains a universal (x86_64 + arm64) Mercurial binary and a self-contained Python 3.13 runtime with all required site-packages.
+
+## Data Source
+
+### Mercurial
+Source code: https://www.mercurial-scm.org/
+Copyright © 2005–2025 Olivia Mackall and contributors.
+Licensed under the GNU General Public License, version 2 or any later version (GPL-2.0-or-later).
+
+### Python
+Source code: https://www.python.org/
+Copyright © 2001–2025 Python Software Foundation.
+Licensed under the Python Software Foundation License Version 2 (PSF-2.0).

--- a/mercurial-macos/SOURCE.md
+++ b/mercurial-macos/SOURCE.md
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67036736efb7ce6ee4a7e1081945f65adc87be6ffbac1c52f07e63e5630ffc1b
+size 1309

--- a/mercurial-macos/hg-macos-universal_7.0.2.tar.xz
+++ b/mercurial-macos/hg-macos-universal_7.0.2.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd7999a855517248d524ccd40ed23fd38692934ac9b99b984f9e42a1747ba1cb
+size 37706748

--- a/mercurial-macos/hg-macos-universal_7.0.2.tar.xz.sha256
+++ b/mercurial-macos/hg-macos-universal_7.0.2.tar.xz.sha256
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b05101b763fa61ec6c49e7316acd9a86a4889bd3b2e95af3cebf0f39555ce649
+size 92


### PR DESCRIPTION
This PR adds a universal (x86_64 + arm64) build of Mercurial for macOS to the dependencies repository.

The bundle includes:
- Mercurial 7.0.2 executable from MacPorts
- Embedded Python 3.13 runtime and standard library
- All required site-packages for Mercurial to run standalone

Testing:
Extracted the tarball and ran:
```bash
./hg-universal/hg version
```
Confirmed output matches expected Mercurial version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/dependencies/6)
<!-- Reviewable:end -->
