### PR TITLE
Add updated sys.path to hg script

### DIFF
--- a/mercurial-macos/SOURCE.md
+++ b/mercurial-macos/SOURCE.md
@@ -16,15 +16,21 @@ To build:
    cp /opt/local/bin/hg hg-universal/
    cp -R /opt/local/Library/Frameworks/Python.framework/Versions/3.13 hg-universal/
    ```
-3. Test:
+3. Add bundled site-packages to `sys.path` so `hg` can find Mercurial libraries
+   1. In `hg` add the following after import statements:
+   ```bash
+   # Add bundled site-packages to sys.path
+   sys.path.insert(0, os.path.join(os.path.dirname(__file__), "3.13", "lib", "python3.13", "site-packages"))
+   ```
+4. Test:
    ```bash
    ./hg-universal/hg version
    ```
-4. Create compressed archive:
+5. Create compressed archive:
    ```bash
    tar -c --xz -f hg-macos-universal.tar.xz hg-universal
    ```
-5. Generate checksum file:
+6. Generate checksum file:
    ```bash
    shasum -a 256 hg-macos-universal.tar.xz > hg-macos-universal.tar.xz.sha256
    ```

--- a/mercurial-macos/hg-macos-universal_7.0.2.tar.xz
+++ b/mercurial-macos/hg-macos-universal_7.0.2.tar.xz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd7999a855517248d524ccd40ed23fd38692934ac9b99b984f9e42a1747ba1cb
-size 37706748
+oid sha256:bef346cde9ce7288f2415c3aeb21c471e7258aaacf0ac5940fe1727a04429bcc
+size 37714884

--- a/mercurial-macos/hg-macos-universal_7.0.2.tar.xz.sha256
+++ b/mercurial-macos/hg-macos-universal_7.0.2.tar.xz.sha256
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b05101b763fa61ec6c49e7316acd9a86a4889bd3b2e95af3cebf0f39555ce649
+oid sha256:ecaf1b6c7a990a8942aedd3d16137dd8cdd40c591bfbe6d4e5bfa6641a5f720e
 size 92


### PR DESCRIPTION
- Add updated `sys.path` to `hg` script
- Rebuild tar and checksum files
- Update `source.md`

This is needed so that the Python libraries contained within this bundle are discoverable. This makes the bundle self-contained.